### PR TITLE
Fixed default argument for refr. index in Steps()

### DIFF
--- a/LightPipes/propagators.py
+++ b/LightPipes/propagators.py
@@ -438,6 +438,9 @@ def Steps(Fin, z, nstep = 1, refr = 1.0, save_ram=False, use_scipy=False):
         
         * :ref:`Examples: Propagation in a lens-like, absorptive medium.<Propagation in a lens-like, absorptive medium.>`
     """
+    if _np.isscalar(refr):
+        #refr. index specified as number, need to expand to 2D grid
+        refr = _np.ones_like(Fin.field) * refr
     if use_scipy:
         print('Warning! Non-functional develop version for testing')
         return _TODOStepsScipy(z, nstep, refr, Fin)


### PR DESCRIPTION
Fixes the problem that the default arg. for refractive index was a scalar. The new behaviour is:
* If no argument for `refr` is supplied, it defaults to `1.0` (as before)
* If no argument is supplied or a (complex) scalar is supplied, like `1.33` or `1.0-1j`, this number is expanded to a 2D grid of correct size with all elements having the same value (homogeneous medium)

NB: As mentioned in the manual (but forgotten in the meantime by me), the change of optical path length by a real refractive index is not fully taken into account, so a homogeneous medium with `refr=1.33` yields the same result as `refr=1.0` and therefore is only interesting with varying refractive index. But of course this fix still makes sense for complex refr. index.