### PR TITLE
Correct order of args to ZernikeFit call in ZernikeFilter

### DIFF
--- a/LightPipes/zernike.py
+++ b/LightPipes/zernike.py
@@ -181,7 +181,7 @@ def ZernikeFilter(F, j_terms, R):
     :rtype: `LightPipes.field.Field`
     
     """
-    j_terms, A_fits = ZernikeFit(j_terms, R, F, norm=True, units='rad')
+    j_terms, A_fits = ZernikeFit(F, j_terms, R, norm=True, units='rad')
     # print(A_fits.round(4))
     # Ph = Phase(F, unwrap=True)
     Ph = _np.zeros_like(F.field)


### PR DESCRIPTION
ZernikeFilter(F, j_terms, R) fails because it calls ZernikeFit(j_terms, R, F, norm=True, units='rad'). This has the old-style arguments order, and ZernikeFit doesn't seem to accept new-style argument order.