### PR TITLE
Use Field.copy on F in ZernikeFilter to prevent in-place modification

### DIFF
--- a/LightPipes/zernike.py
+++ b/LightPipes/zernike.py
@@ -204,10 +204,9 @@ def ZernikeFilter(F, j_terms, R):
         # Ph -= Ph_i
         Ph += Ph_i
     
-    Fout = F
+    Fout = Field.copy(F)
     Fout.field *= _np.exp(-1j * Ph)
-    # Fout = Field.copy(F)
-    # Fout = SubPhase(Ph, Fout)
+
     return Fout
     
 


### PR DESCRIPTION
The line `Fout = F` did not create a copy of F, just a second reference, and the line `Fout.field *= _np.exp(-1j * Ph)` modified the object referenced by both Fout and F, so the input Field also came out filtered.